### PR TITLE
Touchend setContentStyle触摸结束时回弹至刷新位置

### DIFF
--- a/src/PullToRefresh.tsx
+++ b/src/PullToRefresh.tsx
@@ -195,7 +195,13 @@ export default class PullToRefresh extends React.Component<PropsType, any> {
       this.setState({ dragOnEdge: false });
     }
     if (this.state.currSt === 'activate') {
-      this.setState({ currSt: 'release' });
+      if (this.props.direction === UP) {
+        this._lastScreenY = - this.props.distanceToRefresh - 1;
+      }
+      if (this.props.direction === DOWN) {
+        this._lastScreenY = this.props.distanceToRefresh + 1;
+      }
+      this.setState({ currSt: 'release' },() => this.setContentStyle(this._lastScreenY));
       this._timer = setTimeout(() => {
         if (!this.props.refreshing) {
           this.setState({ currSt: 'finish' }, () => this.reset());


### PR DESCRIPTION
修改前效果：触摸结束时，进入“release”状态，滚动容器停留在触摸结束时的滚动位置，当newprops.refreshing===false时，才reset
期望修改后的效果：触摸结束后，进入“release”状态，滚动容器回弹至可容纳loading图标显示的位置，之后如前。