### PR TITLE
fix: update PropsType for optional props

### DIFF
--- a/src/PropsType.ts
+++ b/src/PropsType.ts
@@ -8,14 +8,14 @@ export interface Indicator {
 }
 
 export interface PropsType {
-  getScrollContainer: () => React.ReactNode;
+  getScrollContainer?: () => React.ReactNode;
   direction: 'down' | 'up';
   refreshing?: boolean;
-  distanceToRefresh: number;
+  distanceToRefresh?: number;
   onRefresh: () => void;
-  indicator: Indicator;
+  indicator?: Indicator;
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
-  damping: number;
+  damping?: number;
 }


### PR DESCRIPTION
should not mark optional props as required, such as `getScrollContainer`