### PR TITLE
Prevent scroll locking when scroll distance reaches damping value

### DIFF
--- a/src/PullToRefresh.tsx
+++ b/src/PullToRefresh.tsx
@@ -167,12 +167,12 @@ export default class PullToRefresh extends React.Component<IPropsType, IState> {
   }
 
   damping = (dy: number): number => {
-    if (Math.abs(this._lastScreenY) > this.props.damping) {
-      return 0;
-    }
-
     const ratio = Math.abs(this._ScreenY - this._startScreenY) / window.screen.height;
     dy *= (1 - ratio) * 0.6;
+    
+    if (this._lastScreenY + dy > this.props.damping) {
+      return 0;
+    }
 
     return dy;
   }


### PR DESCRIPTION
In current implementation, calculated distance is always set to 0 when distance hits the damping value, preventing user to scroll in the opposite direction.

This change enables user scrolls in the opposite direction by only locking further scrolling in the intended direction.